### PR TITLE
add link to data in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Once built, several executables are available in `build/bin`:
 Data
 ----
 
-This program need full offsets table to produce best sampling distribution.
+This program needs full offsets table to produce best sampling distribution.
 These tables are heavy (1.5G) and can be downloaded here: http://liris.cnrs.fr/polyhex/data/
 
 


### PR DESCRIPTION
The offsets lut is to heavy to be versionned on github.
I've made the data available on website and put a link in readme.
